### PR TITLE
Makes Urb-it options unavailable if product needs to be backordered

### DIFF
--- a/includes/class-shipping-one-hour.php
+++ b/includes/class-shipping-one-hour.php
@@ -115,6 +115,14 @@
 				$delivery_time = $this->plugin->date($this->plugin->one_hour_offset());
 				
 				if(!$this->plugin->validate->opening_hours($delivery_time)) return false;
+
+				// Check if there are any back-order products in cart
+				foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+					$_product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
+					if ( $_product->is_on_backorder( $cart_item['quantity'] ) ) {
+						return false;
+					}
+				}
 				
 				$is_available = $optional_postcode ? true : $this->plugin->validate->postcode($package['destination']['postcode']);
 				

--- a/includes/class-shipping-specific-time.php
+++ b/includes/class-shipping-specific-time.php
@@ -111,6 +111,14 @@
 				
 				// Check the volume of the order
 				if(!$this->plugin->validate->cart_volume()) return false;
+
+				// Check if there are any back-order products in cart
+				foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+					$_product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
+					if ( $_product->is_on_backorder( $cart_item['quantity'] ) ) {
+						return false;
+					}
+				}
 				
 				$is_available = $optional_postcode ? true : $this->plugin->validate->postcode($package['destination']['postcode']);
 				


### PR DESCRIPTION
I added one more check inside is_available method of both Urb-it shipping methods.

It's very similar to how WooCommerce checks if any of the products need to be backordered. If there's even one product that is on backorder (not enough quantity to deliver right away), then Urb-it methods will not be available.

Tested with simple and variable products.